### PR TITLE
ConstraintsB can express constraints over c a

### DIFF
--- a/src/Data/Barbie.hs
+++ b/src/Data/Barbie.hs
@@ -90,6 +90,8 @@ module Data.Barbie
     -- * Constraints and proofs of instance
   , ConstraintsB(AllB, adjProof)
   , ConstraintsOf
+  , ClassF
+  , ClassFG
   , NotBare
   , ProofB(bproof)
 
@@ -105,6 +107,7 @@ where
 
 import Data.Barbie.Internal.Bare(Bare, BareB(..), bstripFrom, bcoverWith, Wear)
 import Data.Barbie.Internal.Constraints(ConstraintsB(..), ConstraintsOf)
+import Data.Barbie.Internal.Dicts(ClassF, ClassFG)
 import Data.Barbie.Internal.Functor(FunctorB(..))
 import Data.Barbie.Internal.Instances(Barbie(..))
 import Data.Barbie.Internal.ProofB(ProofB(..))

--- a/src/Data/Barbie.hs
+++ b/src/Data/Barbie.hs
@@ -88,8 +88,9 @@ module Data.Barbie
   , bcoverWith
 
     -- * Constraints and proofs of instance
-  , ConstraintsB(AllB, NotBare, adjProof)
+  , ConstraintsB(AllB, adjProof)
   , ConstraintsOf
+  , NotBare
   , ProofB(bproof)
 
     -- * Wrapper
@@ -113,4 +114,6 @@ import Data.Barbie.Internal.Product
   , (/*/), (/*)
   )
 import Data.Barbie.Internal.Traversable(TraversableB(..), bsequence, btraverse_)
+import Data.Barbie.Internal.Wear(NotBare)
+
 import Data.Barbie.Trivial(Void, Unit(..))

--- a/src/Data/Barbie.hs
+++ b/src/Data/Barbie.hs
@@ -53,7 +53,7 @@
 --   = SignUpForm'
 --       { username  :: 'Wear' f 'String',
 --       , password  :: 'Wear' f 'String'
---       , mailingOk :: 'Wear' f 'Boolean'
+--       , mailingOk :: 'Wear' f 'Bool'
 --       }
 --   deriving ( ..., 'BareB')
 --
@@ -88,7 +88,8 @@ module Data.Barbie
   , bcoverWith
 
     -- * Constraints and proofs of instance
-  , ConstraintsB(ConstraintsOf, adjProof)
+  , ConstraintsB(AllB, NotBare, adjProof)
+  , ConstraintsOf
   , ProofB(bproof)
 
     -- * Wrapper
@@ -102,7 +103,7 @@ module Data.Barbie
 where
 
 import Data.Barbie.Internal.Bare(Bare, BareB(..), bstripFrom, bcoverWith, Wear)
-import Data.Barbie.Internal.Constraints(ConstraintsB(..))
+import Data.Barbie.Internal.Constraints(ConstraintsB(..), ConstraintsOf)
 import Data.Barbie.Internal.Functor(FunctorB(..))
 import Data.Barbie.Internal.Instances(Barbie(..))
 import Data.Barbie.Internal.ProofB(ProofB(..))

--- a/src/Data/Barbie/Constraints.hs
+++ b/src/Data/Barbie/Constraints.hs
@@ -33,6 +33,8 @@ module Data.Barbie.Constraints
 
   , ConstraintsOf
   , ClassF
+  , ClassFG
+  , NotBare
   )
 
 where
@@ -40,3 +42,4 @@ where
 import Data.Barbie.Internal.Constraints
 import Data.Barbie.Internal.Dicts
 import Data.Barbie.Internal.ProofB
+import Data.Barbie.Internal.Wear (NotBare)

--- a/src/Data/Barbie/Constraints.hs
+++ b/src/Data/Barbie/Constraints.hs
@@ -24,13 +24,15 @@
 ----------------------------------------------------------------------------
 module Data.Barbie.Constraints
   ( -- * Proof of instance
-    DictOf(..)
-  , packDict
+    Dict(..)
   , requiringDict
 
     -- * Retrieving proofs
-  , ConstraintsB(ConstraintsOf)
+  , ConstraintsB(..)
   , ProofB(..)
+
+  , ConstraintsOf
+  , ClassF
   )
 
 where

--- a/src/Data/Barbie/Internal/Constraints.hs
+++ b/src/Data/Barbie/Internal/Constraints.hs
@@ -12,10 +12,11 @@
 {-# LANGUAGE UndecidableInstances  #-}
 module Data.Barbie.Internal.Constraints
   ( ConstraintsB(..)
+  , ConstraintsOf
 
   , CanDeriveGenericInstance
-  , ConstraintsOfMatchesGenericDeriv
-  , GConstraintsOf
+  , AllBMatchesGenericDeriv
+  , GAllB
   , GAdjProof
   , gadjProofDefault
 
@@ -25,7 +26,7 @@ module Data.Barbie.Internal.Constraints
 where
 
 import Data.Barbie.Internal.Classification (BarbieType(..), ClassifyBarbie, GClassifyBarbie)
-import Data.Barbie.Internal.Dicts(DictOf(..), packDict)
+import Data.Barbie.Internal.Dicts(ClassF, Dict(..))
 import Data.Barbie.Internal.Functor(FunctorB(..))
 import Data.Barbie.Internal.Generics
 import Data.Barbie.Internal.Tags(F, PxF)
@@ -40,7 +41,7 @@ import GHC.Generics
 
 
 -- | Instances of this class provide means to talk about constraints,
---   both at compile-time, using 'ConstraintsOf' and at run-time,
+--   both at compile-time, using 'AllB' and at run-time,
 --   in the form of class instance dictionaries, via 'adjProof'.
 --
 --   A manual definition would look like this:
@@ -49,15 +50,18 @@ import GHC.Generics
 -- data T f = A (f 'Int') (f 'String') | B (f 'Bool') (f 'Int')
 --
 -- instance 'ConstraintsB' T where
---   type 'ConstraintsOf' c f T
---     = (c (f 'Int'), c (f 'String'), c (f 'Bool'))
+--   type 'AllB' c T
+--     = (c 'Int', c 'String', c 'Bool')
+--
+--   type 'NotBare' T f
+--     = ()
 --
 --   adjProof t = case t of
 --     A x y -> A ('Pair' ('packDict' x) ('packDict' y))
 --     B z w -> B ('Pair' ('packDict' z) ('packDict' w))
 -- @
 --
--- There is a default implementation of 'ConstraintsOf' for
+-- There is a default implementation of 'AllB' for
 -- 'Generic' types, so in practice one will simply do:
 --
 -- @
@@ -65,29 +69,48 @@ import GHC.Generics
 -- instance 'ConstraintsB' T
 -- @
 class FunctorB b => ConstraintsB b where
-  -- | @'ConstraintsOf' c f b@ should contain a constraint @c (f x)@
-  --  for each @f x@ occurring in @b@. E.g.:
+  -- | @'AllB' c b@ should contain a constraint @c x@ for each
+  --   @f x@ occurring in @b@. E.g.:
   --
   -- @
-  -- 'ConstraintsOf' 'Show' f Barbie = ('Show' (f 'String'), 'Show' (f 'Int'))
+  -- 'AllB' 'Show' Barbie = ('Show' 'String', 'Show' 'Int')
   -- @
-  type ConstraintsOf (c :: * -> Constraint) (f :: * -> *) b :: Constraint
-  type ConstraintsOf c f b = GConstraintsOf c f (RecRep (b (Target F)))
+  --
+  -- For requiring constraints of the form @c (f a)@, see 'ConstraintsOf'.
+  type AllB (c :: * -> Constraint) b :: Constraint
+  type AllB c b = GAllB c (RecRep (b (Target F)))
+
+  -- | When using 'Wear' in the definition of a Barbie-type, one will sometimes
+  --   need to express that the @f@ in @b f@ is not 'Data.Barbie.Internal.Wear.Bare'.
+  --   We use @'NotBare' b f@ for this. For example:
+  --
+  --   @
+  --   'NotBare' SignUpForm f = ('Wear' f 'String' ~ f 'String', 'Wear' f 'Bool' ~ 'Bool')
+  --   'NotBare' Barbie f = ()
+  --   @
+  type NotBare b (f :: * -> *) :: Constraint
+  type NotBare b f = GNotBare f (RecRep (b (Target F)))
 
   -- | Adjoint a proof-of-instance to a barbie-type.
-  adjProof
-    :: forall c f
-    .  ConstraintsOf c f b
-    => b f -> b (Product (DictOf c f) f)
+  adjProof :: forall c f.  AllB c b => b f -> b (Product (Dict c) f)
 
   default adjProof
     :: forall c f
     .  ( CanDeriveGenericInstance b
-       , ConstraintsOfMatchesGenericDeriv c f b
-       , ConstraintsOf c f b
+       , AllBMatchesGenericDeriv c b
+       , AllB c b
        )
-    => b f -> b (Product (DictOf c f) f)
+    => b f -> b (Product (Dict c) f)
   adjProof = gadjProofDefault
+
+-- | Similar to 'AllB' but will put the functor argument @f@
+--   between the constraint @c@ and the type @a@. For example:
+--
+--   @
+--   'ConstraintsOf' 'Show' f Barbie = ('Show' (f 'String'), c (f 'Int'), 'NotBare' Barbie f)
+--   @
+type ConstraintsOf c f b = (AllB (ClassF c f) b, NotBare b f)
+
 
 -- | Intuivively, the requirements to have @'ConstraintsB' B@ derived are:
 --
@@ -102,9 +125,9 @@ type CanDeriveGenericInstance b
     , Rep (b (Target PxF)) ~ Repl' (Target F) (Target PxF) (RecRep (b (Target F)))
     )
 
-type ConstraintsOfMatchesGenericDeriv c f b
-  = ( ConstraintsOf c f b ~ GConstraintsOf c f (RecRep (b (Target F)))
-    , ConstraintsOf c f b ~ ConstraintByType (ClassifyBarbie b) c f (RecRep (b (Target F)))
+type AllBMatchesGenericDeriv c b
+  = ( AllB c b ~ GAllB c (RecRep (b (Target F)))
+    , AllB c b ~ ConstraintByType (ClassifyBarbie b) c (RecRep (b (Target F)))
     )
 
 
@@ -112,30 +135,45 @@ type ConstraintsOfMatchesGenericDeriv c f b
 --  Generic derivations
 -- ===============================================================
 
-type family ConstraintByType bt (c :: * -> Constraint) (f :: * -> *) r :: Constraint where
-  ConstraintByType bt c f (M1 _i _c x) = ConstraintByType bt c f x
-  ConstraintByType bt c f V1 = ()
-  ConstraintByType bt c f U1 = ()
-  ConstraintByType bt c f (l :*: r) = (ConstraintByType bt c f l, ConstraintByType bt c f r)
-  ConstraintByType bt c f (l :+: r) = (ConstraintByType bt c f l, ConstraintByType bt c f r)
-  ConstraintByType 'WearBarbie c f (K1 R (NonRec (Target (W F) a))) = (c (Wear f a), Wear f a ~ f a)
-  ConstraintByType 'NonWearBarbie c f (K1 R (NonRec (Target F a))) = c (f a)
-  ConstraintByType bt c f (K1 R (NonRec (b (Target F)))) = ConstraintsOf c f b
-  ConstraintByType bt c f (K1 R (RecUsage (b (Target F)))) = () -- break recursion
-  ConstraintByType bt c f (K1 _i _c) = ()
+type family ConstraintByType bt (c :: * -> Constraint) r :: Constraint where
+  ConstraintByType bt c (M1 _i _c x) = ConstraintByType bt c x
+  ConstraintByType bt c V1 = ()
+  ConstraintByType bt c U1 = ()
+  ConstraintByType bt c (l :*: r) = (ConstraintByType bt c l, ConstraintByType bt c r)
+  ConstraintByType bt c (l :+: r) = (ConstraintByType bt c l, ConstraintByType bt c r)
+  ConstraintByType 'WearBarbie c (K1 R (NonRec (Target (W F) a))) = c a
+  ConstraintByType 'NonWearBarbie c (K1 R (NonRec (Target F a))) = c a
+  ConstraintByType bt c (K1 R (NonRec (b (Target F)))) = AllB c b
+  ConstraintByType bt c (K1 R (RecUsage (b (Target F)))) = () -- break recursion
+  ConstraintByType bt c (K1 _i _c) = ()
 
-type GConstraintsOf c f r
-  = ConstraintByType (GClassifyBarbie r) c f r
+type GAllB c r
+  = ConstraintByType (GClassifyBarbie r) c r
+
+type GNotBare f r
+  = NotBareByType (GClassifyBarbie r) f r
+
+type family NotBareByType bt (f :: * -> *) r :: Constraint where
+  NotBareByType 'NonWearBarbie _ _ = ()
+  NotBareByType wbt f (M1 _i _c x) = NotBareByType wbt f x
+  NotBareByType wbt f V1 = ()
+  NotBareByType wbt f U1 = ()
+  NotBareByType wbt f (l :*: r) = (NotBareByType wbt f l, NotBareByType wbt f r)
+  NotBareByType wbt f (l :+: r) = (NotBareByType wbt f l, NotBareByType wbt f r)
+  NotBareByType wbt f (K1 R (NonRec (Target (W F) a))) = Wear f a ~ f a
+  NotBareByType wbt f (K1 R (NonRec (b (Target F)))) = NotBare b f
+  NotBareByType wbt f (K1 R (RecUsage (b (Target F)))) = () -- break recursion
+  NotBareByType wbt f (K1 _i _c) = ()
 
 
 -- | Default implementation of 'adjProof' based on 'Generic'.
 gadjProofDefault
   :: forall b c f
   . ( CanDeriveGenericInstance b
-    , ConstraintsOfMatchesGenericDeriv c f b
-    , ConstraintsOf c f b
+    , AllBMatchesGenericDeriv c b
+    , AllB c b
     )
-  => b f -> b (Product (DictOf c f) f)
+  => b f -> b (Product (Dict c) f)
 gadjProofDefault b
   = unsafeUntargetBarbie @PxF $ to $
       gadjProof pcbf pbt $ fromWithRecAnn (unsafeTargetBarbie @F b)
@@ -147,8 +185,8 @@ gadjProofDefault b
 class GAdjProof (bt :: BarbieType) b rep where
 
   gadjProof
-    :: ( ConstraintByType bt c f rep
-       , GConstraintsOf c f (RecRep (b (Target F))) -- for the recursive case!
+    :: ( ConstraintByType bt c rep
+       , GAllB c (RecRep (b (Target F))) -- for the recursive case
        )
     => Proxy (c (b f))
     -> Proxy bt
@@ -161,27 +199,27 @@ class GAdjProof (bt :: BarbieType) b rep where
 -- ----------------------------------
 
 instance GAdjProof bt b x => GAdjProof bt b (M1 _i _c x) where
-  {-# INLINE gadjProof #-}
   gadjProof pcbf pbt (M1 x)
     = M1 (gadjProof pcbf pbt x)
+  {-# INLINE gadjProof #-}
 
 instance GAdjProof bt b V1 where
   gadjProof _ _ _ = undefined
 
 instance GAdjProof bt b U1 where
-  {-# INLINE gadjProof #-}
   gadjProof _ _ u1 = u1
+  {-# INLINE gadjProof #-}
 
 instance (GAdjProof bt b l, GAdjProof bt b r) => GAdjProof bt b (l :*: r) where
-  {-# INLINE gadjProof #-}
   gadjProof pcbf pbt (l :*: r)
     = (gadjProof pcbf pbt l) :*: (gadjProof pcbf pbt r)
+  {-# INLINE gadjProof #-}
 
 instance (GAdjProof bt b l, GAdjProof bt b r) => GAdjProof bt b (l :+: r) where
-  {-# INLINE gadjProof #-}
   gadjProof pcbf pbt = \case
     L1 l -> L1 (gadjProof pcbf pbt l)
     R1 r -> R1 (gadjProof pcbf pbt r)
+  {-# INLINE gadjProof #-}
 
 
 -- --------------------------------
@@ -189,21 +227,21 @@ instance (GAdjProof bt b l, GAdjProof bt b r) => GAdjProof bt b (l :+: r) where
 -- --------------------------------
 
 instance {-# OVERLAPPING #-} GAdjProof 'WearBarbie b (K1 R (NonRec (Target (W F) a))) where
-  {-# INLINE gadjProof #-}
   gadjProof pcbf _ (K1 (NonRec fa))
     = K1 $ unsafeTarget @(W PxF) (Pair (mkProof pcbf) $ unsafeUntarget @(W F) fa)
     where
-      mkProof :: (c (f a), Wear f a ~ f a) => Proxy (c (b f)) -> DictOf c f a
-      mkProof _ = packDict
+      mkProof :: c a => Proxy (c (b f)) -> Dict c a
+      mkProof _ = Dict
+  {-# INLINE gadjProof #-}
 
 
 instance {-# OVERLAPPING #-} GAdjProof 'NonWearBarbie b (K1 R (NonRec (Target F a))) where
-  {-# INLINE gadjProof #-}
   gadjProof pcbf _ (K1 (NonRec fa))
     = K1 $ unsafeTarget @PxF (Pair (mkProof pcbf) $ unsafeUntarget @F fa)
     where
-      mkProof :: c (f a) => Proxy (c (b f)) -> DictOf c f a
-      mkProof _ = packDict
+      mkProof :: c a => Proxy (c (b f)) -> Dict c a
+      mkProof _ = Dict
+  {-# INLINE gadjProof #-}
 
 
 instance {-# OVERLAPPING #-}
@@ -211,24 +249,24 @@ instance {-# OVERLAPPING #-}
   , bt ~ ClassifyBarbie b
   )
     => GAdjProof bt b (K1 R (RecUsage (b (Target F)))) where
-  {-# INLINE gadjProof #-}
   gadjProof pcbf pbt (K1 (RecUsage bf))
     = K1 $ to $ gadjProof pcbf pbt $ fromWithRecAnn bf
+  {-# INLINE gadjProof #-}
+
 
 instance {-# OVERLAPPING #-}
   ConstraintsB b'
     => GAdjProof bt b (K1 R (NonRec (b' (Target F)))) where
-  {-# INLINE gadjProof #-}
   gadjProof pcbf _ (K1 (NonRec bf))
     = K1 $ unsafeTargetBarbie @PxF $ adjProof' pcbf $ unsafeUntargetBarbie @F bf
     where
       adjProof'
-        :: ConstraintsOf c f b'
-        => Proxy (c (b f)) -> b' f -> b' (Product (DictOf c f) f)
+        :: AllB c b' => Proxy (c (b f)) -> b' f -> b' (Product (Dict c) f)
       adjProof' _ = adjProof
+  {-# INLINE gadjProof #-}
 
 instance
   (K1 i a) ~ Repl' (Target F) (Target PxF) (K1 i (NonRec a))
     => GAdjProof bt b (K1 i (NonRec a)) where
-  {-# INLINE gadjProof #-}
   gadjProof _ _ (K1 (NonRec a)) = K1 a
+  {-# INLINE gadjProof #-}

--- a/src/Data/Barbie/Internal/Constraints.hs
+++ b/src/Data/Barbie/Internal/Constraints.hs
@@ -67,7 +67,7 @@ import GHC.Generics
 -- @
 class FunctorB b => ConstraintsB b where
   -- | @'AllB' c b@ should contain a constraint @c x@ for each
-  --   @f x@ occurring in @b@. E.g.:
+  --   @x@ occurring under an @f@ in @b f@. E.g.:
   --
   -- @
   -- 'AllB' 'Show' Barbie = ('Show' 'String', 'Show' 'Int')

--- a/src/Data/Barbie/Internal/Dicts.hs
+++ b/src/Data/Barbie/Internal/Dicts.hs
@@ -12,6 +12,7 @@ module Data.Barbie.Internal.Dicts
   , requiringDict
 
   , ClassF
+  , ClassFG
   )
 
 where
@@ -36,6 +37,10 @@ instance Show (Dict c a) where
 instance Show1 (Dict c)  where
   liftShowsPrec _ _ = showsPrec
 
+-- | Turn a constrained-function into an unconstrained one
+--   that uses the packed instance dictionary instead.
+requiringDict :: (c  a => r) -> (Dict c a -> r)
+requiringDict r = \Dict -> r
 
 -- | 'ClassF' has one universal instance that makes @'ClassF' c f a@
 --   equivalent to @c (f a)@. However, we have
@@ -49,7 +54,7 @@ instance Show1 (Dict c)  where
 class c (f a) => ClassF c f a where
 instance c (f a) => ClassF c f a
 
--- | Turn a constrained-function into an unconstrained one
---   that uses the packed instance dictionary instead.
-requiringDict :: (c  a => r) -> (Dict c a -> r)
-requiringDict r = \Dict -> r
+
+-- | Like 'ClassF' but for binary relations.
+class c (f a) (g a) => ClassFG c f g a where
+instance c (f a) (g a) => ClassFG c f g a

--- a/src/Data/Barbie/Internal/Dicts.hs
+++ b/src/Data/Barbie/Internal/Dicts.hs
@@ -1,38 +1,55 @@
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE KindSignatures        #-}
-{-# LANGUAGE Rank2Types            #-}
-{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE ConstraintKinds         #-}
+{-# LANGUAGE FlexibleInstances       #-}
+{-# LANGUAGE GADTs                   #-}
+{-# LANGUAGE KindSignatures          #-}
+{-# LANGUAGE MultiParamTypeClasses   #-}
+{-# LANGUAGE Rank2Types              #-}
+{-# LANGUAGE TypeFamilies            #-}
+{-# LANGUAGE UndecidableInstances    #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 module Data.Barbie.Internal.Dicts
-  ( DictOf(..)
-  , packDict
+  ( Dict(..)
   , requiringDict
+
+  , ClassF
   )
 
 where
 
 import Data.Functor.Classes(Show1(..))
 
--- | @'DictOf' c f a@ is evidence that there exists an instance
---   of @c (f a)@.
-data DictOf c f a where
-  PackedDict :: c (f a) => DictOf c f a
 
+-- | @'Dict' c a@ is evidence that there exists an instance of @c a@.
+--
+--   It is essentially equivalent to @Dict (c a)@ from the
+--   <http://hackage.haskell.org/package/constraints constraints> package,
+--   but because of its kind, it allows us to define things like @'Dict' 'Show'@.
+data Dict c a where
+  Dict :: c a => Dict c a
 
-instance Eq (DictOf c f a) where
+instance Eq (Dict c a) where
   _ == _ = True
 
-instance Show (DictOf c f a) where
-  showsPrec _ PackedDict = showString "PackedDict"
+instance Show (Dict c a) where
+  showsPrec _ Dict = showString "Dict"
 
-instance Show1 (DictOf c f) where
+instance Show1 (Dict c)  where
   liftShowsPrec _ _ = showsPrec
 
--- | Pack the dictionary associated with an instance.
-packDict :: c (f a) => DictOf c f a
-packDict = PackedDict
+
+-- | 'ClassF' has one universal instance that makes @'ClassF' c f a@
+--   equivalent to @c (f a)@. However, we have
+--
+-- @
+-- 'ClassF c f :: * -> 'Constraint'
+-- @
+--
+-- This is useful since it allows to define constraint-constructors like
+-- @'ClassF' 'Monoid' 'Maybe'@
+class c (f a) => ClassF c f a where
+instance c (f a) => ClassF c f a
 
 -- | Turn a constrained-function into an unconstrained one
 --   that uses the packed instance dictionary instead.
-requiringDict :: (c (f a) => r) -> (DictOf c f a -> r)
-requiringDict r = \PackedDict -> r
+requiringDict :: (c  a => r) -> (Dict c a -> r)
+requiringDict r = \Dict -> r

--- a/src/Data/Barbie/Internal/Instances.hs
+++ b/src/Data/Barbie/Internal/Instances.hs
@@ -23,23 +23,23 @@ newtype Barbie b (f :: * -> *)
 
 -- Need to derive it manually to make GHC 8.0.2 happy
 instance ConstraintsB b => ConstraintsB (Barbie b) where
-  type ConstraintsOf c f (Barbie b) = ConstraintsOf c f b
+  type AllB c (Barbie b) = AllB c b
   adjProof = Barbie . adjProof . getBarbie
 
 instance TraversableB b => TraversableB (Barbie b) where
   btraverse f = fmap Barbie . btraverse f . getBarbie
 
 
-instance (ProofB b, ConstraintsOf Semigroup f b) => Semigroup (Barbie b f) where
+instance (ProofB b, AllB (ClassF Semigroup f) b) => Semigroup (Barbie b f) where
   (<>) = bzipWith3 mk bproof
     where
-      mk :: DictOf Semigroup f a -> f a -> f a -> f a
+      mk :: Dict (ClassF Semigroup f) a -> f a -> f a -> f a
       mk = requiringDict (<>)
 
-instance (ProofB b, ConstraintsOf Semigroup f b, ConstraintsOf Monoid f b) => Monoid (Barbie b f) where
+instance (ProofB b, AllB (ClassF Semigroup f) b, AllB (ClassF Monoid f) b) => Monoid (Barbie b f) where
   mempty = bmap mk bproof
     where
-      mk :: DictOf Monoid f a -> f a
+      mk :: Dict (ClassF Monoid f) a -> f a
       mk = requiringDict mempty
 
   mappend = (<>)

--- a/src/Data/Barbie/Internal/Wear.hs
+++ b/src/Data/Barbie/Internal/Wear.hs
@@ -1,6 +1,9 @@
-{-# LANGUAGE TypeFamilies       #-}
+{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE TypeFamilies           #-}
 module Data.Barbie.Internal.Wear
   ( Bare, Wear
+  , NotBare
   )
 
 where
@@ -32,3 +35,9 @@ type family Wear f a where
 
 -- | 'Bare' is the only type such that @'Wear' 'Bare' a ~ a'@.
 data Bare a
+
+-- | 'NotBare' has one universal instance that makes @'NotBare' f a@
+--   equivalent to @'Wear' f a ~ f a@. This will hold every time
+--   `f` is not `Bare`.
+class Wear f a ~ f a => NotBare f a where
+instance Wear f a ~ f a => NotBare f a

--- a/test/Spec/Constraints.hs
+++ b/test/Spec/Constraints.hs
@@ -9,7 +9,7 @@ where
 
 import Clothes(F)
 import Data.Barbie(bmap, ConstraintsB(..), ProofB(..))
-import Data.Barbie.Constraints(DictOf)
+import Data.Barbie.Constraints(ClassF, Dict)
 
 import Data.Functor.Product (Product(Pair))
 import Data.Typeable(Typeable, Proxy(..), typeRep)
@@ -20,7 +20,7 @@ import Test.Tasty.QuickCheck(Arbitrary(..), testProperty, (===))
 
 lawAdjProofPrj
   :: forall b
-  . ( ConstraintsB b, ConstraintsOf Show F b
+  . ( ConstraintsB b, AllB (ClassF Show F) b
     , Eq (b F)
     , Show (b F)
     , Arbitrary (b F)
@@ -29,22 +29,22 @@ lawAdjProofPrj
   => TestTree
 lawAdjProofPrj
   = testProperty (show (typeRep (Proxy :: Proxy b))) $ \b ->
-      bmap second (adjProof b :: b (Product (DictOf Show F) F)) === b
+      bmap second (adjProof b :: b (Product (Dict (ClassF Show F)) F)) === b
   where
     second (Pair _ b) = b
 
 
 lawProofEquivPrj
   :: forall b
-  . ( ProofB b, ConstraintsOf Show F b
-    , Eq (b (DictOf Show F))
-    , Show (b F), Show (b (DictOf Show F))
+  . ( ProofB b, AllB (ClassF Show F) b
+    , Eq (b (Dict (ClassF Show F)))
+    , Show (b F), Show (b (Dict (ClassF Show F)))
     , Arbitrary (b F)
     , Typeable b
     )
   => TestTree
 lawProofEquivPrj
   = testProperty (show (typeRep (Proxy :: Proxy b))) $ \b ->
-      bmap first (adjProof b :: b (Product (DictOf Show F) F)) === bproof
+      bmap first (adjProof b :: b (Product (Dict (ClassF Show F)) F)) === bproof
   where
     first (Pair a _) = a


### PR DESCRIPTION
The `ConstraintsB` class was defining an associated type `ConstraintsOf` that one could use to get constraints of the form `c (f a)`. We now use a more general mechanism and make `ConstraintsB` a type alias for backwards compatiblity.

The way things now work is as follows:

  - `ConstraintsB` has an associated type `AllB c b`. Given a constraint-constructor `c` and a barbie `b` it will produce a constraint `(c x1, c x2, ... c xn)` for each type `xi` under an `f` in `b`.

  - How do we plug an `f` as `ConstraintsOf` used to do? The trick is to define the following class, along with its universal instance:
    ```
    class c (f a) => ClassF c f a
    instance c (f a) => ClassF c f a
    ```
    And now `ConstraintsOf c f b` becomes essentially `AllB (ClassF c f) b`.

  - Actually, for barbies defined with `Wear`, `ConstraintsOf c f b` was also adding constraints of the form `(Wear f x1 ~ f x1`,... Wear f xn ~ f xn)`. We add a second associated type to 'ConstraintsB`, called 'NotBare b f` that builds this constraint on `Wear`-barbies and `()` otherwise.

Credit goes to Csongor Kiss for this very nice formulation.