### PR TITLE
Instances for base types

### DIFF
--- a/src/Data/Barbie/Internal/Constraints.hs
+++ b/src/Data/Barbie/Internal/Constraints.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE AllowAmbiguousTypes   #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE AllowAmbiguousTypes  #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE UndecidableInstances #-}
 module Data.Barbie.Internal.Constraints
   ( ConstraintsB(..)
   , AllBF
@@ -19,11 +19,14 @@ module Data.Barbie.Internal.Constraints
 
 where
 
-import Data.Barbie.Internal.Dicts(ClassF, Dict(..))
-import Data.Barbie.Internal.Functor(FunctorB(..))
+import Data.Barbie.Internal.Dicts   (ClassF, Dict (..))
+import Data.Barbie.Internal.Functor (FunctorB (..))
 
-import Data.Functor.Product(Product(..))
-import Data.Kind(Constraint)
+import Data.Functor.Const   (Const (..))
+import Data.Functor.Product (Product (..))
+import Data.Functor.Sum     (Sum (..))
+import Data.Kind            (Constraint)
+import Data.Proxy           (Proxy (..))
 
 import Data.Generics.GenericN
 
@@ -312,3 +315,33 @@ type family TagSelf (b :: (* -> *) -> *) (repbf :: * -> *) :: * -> * where
 
   TagSelf b V1
     = V1
+
+
+-- --------------------------------
+-- Instances for base types
+-- --------------------------------
+
+instance ConstraintsB Proxy where
+  type AllB c Proxy = ()
+
+  baddDicts _ = Proxy
+  {-# INLINE baddDicts #-}
+
+instance (ConstraintsB a, ConstraintsB b) => ConstraintsB (Product a b) where
+  type AllB c (Product a b) = (AllB c a, AllB c b)
+
+  baddDicts (Pair x y) = Pair (baddDicts x) (baddDicts y)
+  {-# INLINE baddDicts #-}
+
+instance (ConstraintsB a, ConstraintsB b) => ConstraintsB (Sum a b) where
+  type AllB c (Sum a b) = (AllB c a, AllB c b)
+
+  baddDicts (InL x) = InL (baddDicts x)
+  baddDicts (InR x) = InR (baddDicts x)
+  {-# INLINE baddDicts #-}
+
+instance ConstraintsB (Const a) where
+  type AllB c (Const a) = ()
+
+  baddDicts (Const x) = Const x
+  {-# INLINE baddDicts #-}

--- a/src/Data/Barbie/Internal/Functor.hs
+++ b/src/Data/Barbie/Internal/Functor.hs
@@ -130,13 +130,17 @@ instance GFunctorB f g (Rec x x) (Rec x x) where
 
 instance FunctorB Proxy where
   bmap _ _ = Proxy
+  {-# INLINE bmap #-}
 
 instance (FunctorB a, FunctorB b) => FunctorB (Product a b) where
   bmap f (Pair x y) = Pair (bmap f x) (bmap f y)
+  {-# INLINE bmap #-}
 
 instance (FunctorB a, FunctorB b) => FunctorB (Sum a b) where
   bmap f (InL x) = InL (bmap f x)
   bmap f (InR x) = InR (bmap f x)
+  {-# INLINE bmap #-}
 
 instance FunctorB (Const x) where
   bmap _ (Const x) = Const x
+  {-# INLINE bmap #-}

--- a/src/Data/Barbie/Internal/Functor.hs
+++ b/src/Data/Barbie/Internal/Functor.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeFamilies #-}
 module Data.Barbie.Internal.Functor
   ( FunctorB(..)
 
@@ -9,7 +9,11 @@ module Data.Barbie.Internal.Functor
 
 where
 
+import Data.Functor.Const     (Const (..))
+import Data.Functor.Product   (Product (..))
+import Data.Functor.Sum       (Sum (..))
 import Data.Generics.GenericN
+import Data.Proxy             (Proxy (..))
 
 -- | Barbie-types that can be mapped over. Instances of 'FunctorB' should
 --   satisfy the following laws:
@@ -118,3 +122,21 @@ instance
 instance GFunctorB f g (Rec x x) (Rec x x) where
   gbmap _ = id
   {-# INLINE gbmap #-}
+
+
+-- --------------------------------
+-- Instances for base types
+-- --------------------------------
+
+instance FunctorB Proxy where
+  bmap _ _ = Proxy
+
+instance (FunctorB a, FunctorB b) => FunctorB (Product a b) where
+  bmap f (Pair x y) = Pair (bmap f x) (bmap f y)
+
+instance (FunctorB a, FunctorB b) => FunctorB (Sum a b) where
+  bmap f (InL x) = InL (bmap f x)
+  bmap f (InR x) = InR (bmap f x)
+
+instance FunctorB (Const x) where
+  bmap _ (Const x) = Const x

--- a/src/Data/Barbie/Internal/Product.hs
+++ b/src/Data/Barbie/Internal/Product.hs
@@ -13,10 +13,12 @@ module Data.Barbie.Internal.Product
 
 where
 
-import Data.Barbie.Internal.Functor(FunctorB(..))
+import Data.Barbie.Internal.Functor (FunctorB (..))
 
-import Data.Functor.Product (Product(..))
+import Data.Functor.Const   (Const (..))
 import Data.Functor.Prod
+import Data.Functor.Product (Product (..))
+import Data.Proxy           (Proxy (..))
 
 import Data.Generics.GenericN
 
@@ -237,3 +239,29 @@ instance
 
   gbuniq x = Rec (K1 (buniq x))
   {-# INLINE gbuniq #-}
+
+
+-- --------------------------------
+-- Instances for base types
+-- --------------------------------
+
+instance ProductB Proxy where
+  bprod _ _ = Proxy
+  {-# INLINE bprod #-}
+
+  buniq _ = Proxy
+  {-# INLINE buniq #-}
+
+instance (ProductB a, ProductB b) => ProductB (Product a b) where
+  bprod (Pair ll lr) (Pair rl rr) = Pair (bprod ll rl) (bprod lr rr)
+  {-# INLINE bprod #-}
+
+  buniq x = Pair (buniq x) (buniq x)
+  {-# INLINE buniq #-}
+
+instance Monoid a => ProductB (Const a) where
+  bprod (Const x) (Const y) = Const (x <> y)
+  {-# INLINE bprod #-}
+
+  buniq _ = Const mempty
+  {-# INLINE buniq #-}

--- a/src/Data/Barbie/Internal/ProductC.hs
+++ b/src/Data/Barbie/Internal/ProductC.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE AllowAmbiguousTypes   #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE AllowAmbiguousTypes  #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE UndecidableInstances #-}
 module Data.Barbie.Internal.ProductC
   ( ProductBC(..)
   , buniqC
@@ -19,11 +19,15 @@ module Data.Barbie.Internal.ProductC
 where
 
 import Data.Barbie.Internal.Constraints
-import Data.Barbie.Internal.Dicts(ClassF, Dict(..), requiringDict)
-import Data.Barbie.Internal.Functor(bmap)
-import Data.Barbie.Internal.Product(ProductB(..))
+import Data.Barbie.Internal.Dicts       (ClassF, Dict (..), requiringDict)
+import Data.Barbie.Internal.Functor     (bmap)
+import Data.Barbie.Internal.Product     (ProductB (..))
 
 import Data.Generics.GenericN
+
+import Data.Functor.Const   (Const (..))
+import Data.Functor.Product (Product (..))
+import Data.Proxy           (Proxy (..))
 
 -- | Every type @b@ that is an instance of both 'ProductB' and
 --   'ConstraintsB' can be made an instance of 'ProductBC'
@@ -152,3 +156,20 @@ instance
                     (Rec       (b (P0 (Dict c)))
                                (b'    (Dict c))) where
   gbdicts = Rec $ K1 $ bdicts @b'
+
+
+-- --------------------------------
+-- Instances for base types
+-- --------------------------------
+
+instance ProductBC Proxy where
+  bdicts = Proxy
+  {-# INLINE bdicts #-}
+
+instance (ProductBC a, ProductBC b) => ProductBC (Product a b) where
+  bdicts = Pair bdicts bdicts
+  {-# INLINE bdicts #-}
+
+instance Monoid a => ProductBC (Const a) where
+  bdicts = Const mempty
+  {-# INLINE bdicts #-}


### PR DESCRIPTION
This adds instances 

- `FunctorB`
- `TraversableB`
- `ProductB`
- `ConstraintsB`
- `ProductBC`

for base types
- `Proxy` (this corresponds to your `Unit` type)
- `Product`
- `Sum`
- `Const`