### PR TITLE
Make barbies polykinded

### DIFF
--- a/src/Data/Barbie.hs
+++ b/src/Data/Barbie.hs
@@ -2,7 +2,7 @@
 -- |
 -- Module      :  Data.Barbie
 --
--- A common Haskell idiom is to parameterise a datatype by a type @* -> *@,
+-- A common Haskell idiom is to parameterise a datatype by a type @k -> *@,
 -- typically a functor or a GADT. These are like outfits of a Barbie,
 -- that turn her into a different doll. E.g.
 --
@@ -41,6 +41,20 @@
 -- and it may feel like a second-class record type, where one needs to
 -- unpack values in each field. "Data.Barbie.Bare" offers a way to have
 -- bare versions of a barbie-type.
+--
+-- Notice that all classes in this package are poly-kinded. Intuitively,
+-- a barbie is a type parameterised by a functor, and because a barbies is
+-- a type of functor, a type parameterised by a barbie is a (higher-kinded)
+-- barbie too:
+--
+-- @
+-- data Catalog b
+--   = Catalog (b 'Identity') (b 'Maybe')
+--   deriving
+--     ('GHC.Generics.Generic'
+--     , 'FunctorB', 'TraversableB', 'ProductB', 'ConstraintsB', 'ProductBC'
+--     )
+-- @
 
 
 ----------------------------------------------------------------------------

--- a/src/Data/Barbie/Internal/Constraints.hs
+++ b/src/Data/Barbie/Internal/Constraints.hs
@@ -23,6 +23,7 @@ where
 import Data.Barbie.Internal.Dicts   (ClassF, Dict (..))
 import Data.Barbie.Internal.Functor (FunctorB (..))
 
+import Data.Functor.Compose (Compose (..))
 import Data.Functor.Const   (Const (..))
 import Data.Functor.Product (Product (..))
 import Data.Functor.Sum     (Sum (..))
@@ -345,4 +346,11 @@ instance ConstraintsB (Const a) where
   type AllB c (Const a) = ()
 
   baddDicts (Const x) = Const x
+  {-# INLINE baddDicts #-}
+
+instance (Functor f, ConstraintsB b) => ConstraintsB (f `Compose` b) where
+  type AllB c (f `Compose` b) = AllB c b
+
+  baddDicts (Compose x)
+    = Compose (baddDicts <$> x)
   {-# INLINE baddDicts #-}

--- a/src/Data/Barbie/Internal/Dicts.hs
+++ b/src/Data/Barbie/Internal/Dicts.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GADTs                   #-}
+{-# LANGUAGE PolyKinds               #-}
 {-# LANGUAGE TypeFamilies            #-}
 {-# LANGUAGE UndecidableInstances    #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
@@ -12,7 +13,7 @@ module Data.Barbie.Internal.Dicts
 
 where
 
-import Data.Functor.Classes(Show1(..))
+import Data.Functor.Classes (Show1(..))
 
 
 -- | @'Dict' c a@ is evidence that there exists an instance of @c a@.
@@ -41,7 +42,7 @@ requiringDict r = \Dict -> r
 --   equivalent to @c (f a)@. However, we have
 --
 -- @
--- 'ClassF c f :: * -> 'Constraint'
+-- 'ClassF c f :: k -> 'Constraint'
 -- @
 --
 -- This is useful since it allows to define constraint-constructors like

--- a/src/Data/Barbie/Internal/Functor.hs
+++ b/src/Data/Barbie/Internal/Functor.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PolyKinds    #-}
 {-# LANGUAGE TypeFamilies #-}
 module Data.Barbie.Internal.Functor
   ( FunctorB(..)
@@ -14,6 +15,7 @@ import Data.Functor.Product   (Product (..))
 import Data.Functor.Sum       (Sum (..))
 import Data.Generics.GenericN
 import Data.Proxy             (Proxy (..))
+import Data.Kind              (Type)
 
 -- | Barbie-types that can be mapped over. Instances of 'FunctorB' should
 --   satisfy the following laws:
@@ -25,7 +27,7 @@ import Data.Proxy             (Proxy (..))
 --
 -- There is a default 'bmap' implementation for 'Generic' types, so
 -- instances can derived automatically.
-class FunctorB b where
+class FunctorB (b :: (k -> Type) -> Type) where
   bmap :: (forall a . f a -> g a) -> b f -> b g
 
   default bmap

--- a/src/Data/Barbie/Internal/Functor.hs
+++ b/src/Data/Barbie/Internal/Functor.hs
@@ -10,6 +10,7 @@ module Data.Barbie.Internal.Functor
 
 where
 
+import Data.Functor.Compose   (Compose (..))
 import Data.Functor.Const     (Const (..))
 import Data.Functor.Product   (Product (..))
 import Data.Functor.Sum       (Sum (..))
@@ -145,4 +146,8 @@ instance (FunctorB a, FunctorB b) => FunctorB (Sum a b) where
 
 instance FunctorB (Const x) where
   bmap _ (Const x) = Const x
+  {-# INLINE bmap #-}
+
+instance (Functor f, FunctorB b) => FunctorB (f `Compose` b) where
+  bmap h (Compose x) = Compose (bmap h <$> x)
   {-# INLINE bmap #-}

--- a/src/Data/Barbie/Internal/Instances.hs
+++ b/src/Data/Barbie/Internal/Instances.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PolyKinds                  #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
 module Data.Barbie.Internal.Instances ( Barbie(..) )
@@ -12,10 +13,11 @@ import Data.Barbie.Internal.Traversable
 import Data.Barbie.Internal.Product
 import Data.Barbie.Internal.ProductC
 
+import Data.Kind (Type)
 import Data.Semigroup (Semigroup, (<>))
 
 -- | A wrapper for Barbie-types, providing useful instances.
-newtype Barbie b (f :: * -> *)
+newtype Barbie (b :: (k -> Type) -> Type) f
   = Barbie { getBarbie :: b f }
   deriving (FunctorB, ProductB, ProductBC)
 

--- a/src/Data/Barbie/Internal/Product.hs
+++ b/src/Data/Barbie/Internal/Product.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes  #-}
+{-# LANGUAGE PolyKinds            #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE UndecidableInstances #-}
 module Data.Barbie.Internal.Product
@@ -17,6 +18,7 @@ import Data.Barbie.Internal.Functor (FunctorB (..))
 
 import Data.Functor.Prod
 import Data.Functor.Product (Product (..))
+import Data.Kind            (Type)
 import Data.Proxy           (Proxy (..))
 
 import Data.Generics.GenericN
@@ -60,7 +62,7 @@ import Data.Generics.GenericN
 --
 -- There is a default implementation of 'bprod' and 'buniq' for 'Generic' types,
 -- so instances can derived automatically.
-class FunctorB b => ProductB b where
+class FunctorB b => ProductB (b :: (k -> Type) -> Type) where
   bprod :: b f -> b g -> b (f `Product` g)
 
   buniq :: (forall a . f a) -> b f
@@ -166,7 +168,7 @@ gbuniqDefault x
   = toN (gbuniq @f @f @_ @(RepN (b f)) @(RepN (b (f `Product` f))) x)
 {-# INLINE gbuniqDefault #-}
 
-class GProductB (f :: * -> *) (g :: * -> *) repbf repbg repbfg where
+class GProductB (f :: k -> *) (g :: k -> *) repbf repbg repbfg where
   gbprod :: repbf x -> repbg x -> repbfg x
 
   gbuniq :: (forall a . f a) -> repbf x

--- a/src/Data/Barbie/Internal/ProductC.hs
+++ b/src/Data/Barbie/Internal/ProductC.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes  #-}
+{-# LANGUAGE PolyKinds            #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE UndecidableInstances #-}
 module Data.Barbie.Internal.ProductC
@@ -22,6 +23,7 @@ import Data.Barbie.Internal.Constraints
 import Data.Barbie.Internal.Dicts       (ClassF, Dict (..), requiringDict)
 import Data.Barbie.Internal.Functor     (bmap)
 import Data.Barbie.Internal.Product     (ProductB (..))
+import Data.Kind                        (Type)
 
 import Data.Generics.GenericN
 
@@ -54,7 +56,7 @@ import Data.Proxy           (Proxy (..))
 --
 -- There is a default implementation for 'Generic' types, so
 -- instances can derived automatically.
-class (ConstraintsB b, ProductB b) => ProductBC b where
+class (ConstraintsB b, ProductB b) => ProductBC (b :: (k -> Type) -> Type) where
   bdicts :: AllB c b => b (Dict c)
 
   default bdicts :: (CanDeriveProductBC c b, AllB c b) => b (Dict c)
@@ -145,7 +147,7 @@ instance
   ) => GProductBC c (Rec (Self b (P0 X)) (b X))
                     (Rec      (b (P0 (Dict c)))
                               (b     (Dict c))) where
-  gbdicts = Rec $ K1 $ bdicts @b
+  gbdicts = Rec $ K1 $ bdicts @_ @b
 
 instance
   ( SameOrParam b b'
@@ -154,7 +156,7 @@ instance
   ) => GProductBC c (Rec (Other b (P0 X)) (b' X))
                     (Rec       (b (P0 (Dict c)))
                                (b'    (Dict c))) where
-  gbdicts = Rec $ K1 $ bdicts @b'
+  gbdicts = Rec $ K1 $ bdicts @_ @b'
 
 
 -- --------------------------------

--- a/src/Data/Barbie/Internal/Traversable.hs
+++ b/src/Data/Barbie/Internal/Traversable.hs
@@ -230,3 +230,8 @@ instance (TraversableB a, TraversableB b) => TraversableB (Sum a b) where
 instance TraversableB (Const a) where
   btraverse _ (Const x) = pure (Const x)
   {-# INLINE btraverse #-}
+
+instance (Traversable f, TraversableB b) => TraversableB (f `Compose` b) where
+  btraverse h (Compose x)
+    = Compose <$> traverse (btraverse h) x
+  {-# INLINE btraverse #-}

--- a/src/Data/Barbie/Internal/Traversable.hs
+++ b/src/Data/Barbie/Internal/Traversable.hs
@@ -2,6 +2,7 @@
 -- |
 -- Module      :  Data.Barbie.Internal.Traversable
 ----------------------------------------------------------------------------
+{-# LANGUAGE PolyKinds    #-}
 {-# LANGUAGE TypeFamilies #-}
 module Data.Barbie.Internal.Traversable
   ( TraversableB(..)
@@ -25,6 +26,7 @@ import Data.Functor.Const     (Const (..))
 import Data.Functor.Identity  (Identity (..))
 import Data.Functor.Product   (Product (..))
 import Data.Functor.Sum       (Sum (..))
+import Data.Kind              (Type)
 import Data.Generics.GenericN
 import Data.Proxy             (Proxy (..))
 
@@ -39,7 +41,7 @@ import Data.Proxy             (Proxy (..))
 --
 -- There is a default 'btraverse' implementation for 'Generic' types, so
 -- instances can derived automatically.
-class FunctorB b => TraversableB b where
+class FunctorB b => TraversableB (b :: (k -> Type) -> Type) where
   btraverse :: Applicative t => (forall a . f a -> t (g a)) -> b f -> t (b g)
 
   default btraverse

--- a/src/Data/Barbie/Trivial.hs
+++ b/src/Data/Barbie/Trivial.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PolyKinds #-}
 module Data.Barbie.Trivial
   ( Void
   , Unit (..)
@@ -12,6 +13,7 @@ import Data.Barbie.Internal.ProductC(ProductBC(..))
 import Data.Barbie.Internal.Traversable(TraversableB(..))
 
 import Data.Data (Data(..))
+import Data.Kind (Type)
 import Data.Semigroup (Semigroup(..))
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
@@ -22,7 +24,7 @@ import GHC.Generics (Generic)
 ---------------------------------------------------
 
 -- | Uninhabited barbie type.
-data Void (f :: * -> *)
+data Void (f :: k -> Type)
   deriving (Generic, Typeable)
 
 instance Eq   (Void f) where
@@ -44,7 +46,7 @@ instance ConstraintsB Void
 
 
 -- | A barbie type without structure.
-data Unit (f :: * -> *)
+data Unit (f :: k -> Type)
   = Unit
   deriving
     ( Data, Generic, Typeable

--- a/src/Data/Functor/Prod.hs
+++ b/src/Data/Functor/Prod.hs
@@ -42,11 +42,12 @@ where
 import Control.Applicative(Alternative(..))
 import Data.Functor.Product(Product(..))
 import Data.Functor.Classes(Eq1(..), Ord1(..), Show1(..))
+import Data.Kind (Type)
 
 import qualified Data.Functor.Classes as FC
 
 -- | Product of n functors.
-data Prod :: [* -> *] -> * -> * where
+data Prod :: [k -> Type] -> k -> Type where
   Unit :: Prod '[] a
   Cons :: (f a) -> Prod fs a -> Prod (f ': fs) a
 

--- a/src/Data/Generics/GenericN.hs
+++ b/src/Data/Generics/GenericN.hs
@@ -33,7 +33,7 @@ import GHC.Generics
 import GHC.TypeLits
 import Data.Coerce
 
-data Param (n :: Nat) (original :: k' -> k'') (a :: k)
+data Param (n :: Nat) (original :: k -> k') (a :: k)
 
 type family Indexed (t :: k) (i :: Nat) :: k where
   Indexed (t a) i = Indexed t (i + 1) (Param i a)

--- a/test/Barbies.hs
+++ b/test/Barbies.hs
@@ -20,6 +20,8 @@ module Barbies
   , InfRec(..)
 
   , NestedF(..)
+
+  , HKB(..)
   )
 
 where
@@ -282,3 +284,21 @@ instance TraversableB (ParX a)
 instance ProductB (ParX a)
 instance ConstraintsB (ParX a)
 instance ProductBC (ParX a)
+
+
+-----------------------------------------------------
+-- Higher-kinded barbies
+-----------------------------------------------------
+
+data HKB b
+  = HKB
+      { hkb1 :: b Maybe
+      , khb2 :: b ([])
+      }
+  deriving (Generic, Typeable)
+
+instance FunctorB HKB
+instance TraversableB HKB
+instance ProductB HKB
+instance ConstraintsB HKB
+instance ProductBC HKB


### PR DESCRIPTION
Generalizes barbies from being types of kind `(Type -> Type) -> Type` to kind `(k -> Type) -> Type`.

See #7 