### PR TITLE
Add bmapC to allow mapping with constraints

### DIFF
--- a/src/Data/Barbie.hs
+++ b/src/Data/Barbie.hs
@@ -80,6 +80,8 @@ module Data.Barbie
     -- * Constraints and instance dictionaries
   , ConstraintsB(AllB, baddDicts)
   , AllBF
+    -- ** Utility functions
+  , bmapC
 
     -- * Products and constaints
   , ProductBC(bdicts)
@@ -106,7 +108,7 @@ module Data.Barbie
 
 where
 
-import Data.Barbie.Internal.Constraints(ConstraintsB(..), AllBF)
+import Data.Barbie.Internal.Constraints(ConstraintsB(..), AllBF, bmapC)
 import qualified Data.Barbie.Internal.Constraints as Deprecated
 
 import Data.Barbie.Internal.Functor(FunctorB(..))

--- a/src/Data/Barbie/Constraints.hs
+++ b/src/Data/Barbie/Constraints.hs
@@ -30,6 +30,7 @@ module Data.Barbie.Constraints
     -- * Retrieving dictionaries
   , ConstraintsB(..)
   , ProductBC(..)
+  , bmapC
 
   , AllBF
   , ClassF

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -11,9 +11,10 @@ import qualified Spec.Wrapper as Wrapper
 import Barbies
 import BarbiesW
 
-import Data.Barbie (bfoldMap)
+import Data.Barbie (bfoldMap, bmapC, buniqC)
 import Data.Barbie.Bare(Covered)
 import Data.Functor.Const(Const(..))
+import Data.Functor.Identity(Identity(..))
 
 main :: IO ()
 main
@@ -181,4 +182,17 @@ main
                 let b = Record3 (Const "tic") (Const "tac") (Const "toe")
                 bfoldMap getConst b @?= "tictactoe"
             ]
+        , testGroup
+          "bmapC"
+          [ testCase "Record1" $
+                bmapC @Num (fmap (+1)) (Record1 (Identity 0))
+                    @?= Record1 (Identity 1)
+          ]
+        , testGroup
+          "buniqC"
+          [ testCase "Record1" $
+                buniqC @Num (Identity (fromIntegral (42 :: Int)))
+                    @?= Record1 (Identity 42)
+          ]
         ]
+


### PR DESCRIPTION
Hey there! I've been intrigued by the possibility of using HKD for form libraries, json deserialization, etc. For most of these things though I need to be able to make assumptions about the underlying data using constraints. I think most of the combinators could probably benefit from a constraint scoped version, but figured I'd start off with `bmapC`.

I'm not sure how you prefer to add tests for these sorts of things, but noticed you didn't have tests for `buniqC` so I figured I'd just ask 😄 

Motivation:

Here's just one example where I may need to assert that all members of the Record have `FromJSON` in my `bMap`; this example lets me deserialize each field or error by using a record full of aeson keys.

```haskell
data User f = User
  { userId :: f String
  , country :: f String
  , interests :: f [String]
  , age :: f Int
  } deriving ( Generic
             , FunctorB, TraversableB, ProductB, ConstraintsB, ProductBC
             )

deriving instance (forall a. Show a => Show (f a)) => Show (User f)

jsonKeys :: User (Const T.Text)
jsonKeys = User
  { userId    = Const "user_id"
  , country   = Const "country"
  , interests = Const "interests"
  , age       = Const "age"
  }


userFromJson :: User (ReaderT Value Maybe)
userFromJson = bmapC @FromJSON (atKey . getConst) jsonKeys
 where
  atKey :: FromJSON a => T.Text -> ReaderT Value Maybe a
  atKey k = do
    v <- ask
    lift (preview (key k) v >>= fromResult . fromJSON)

fromResult :: Result a -> Maybe a
fromResult (Success a) = Just a
fromResult _           = Nothing
```