### PR TITLE
Raise an error if `Wear` is used with incompatible tag

### DIFF
--- a/src/Data/Barbie/Internal/Wear.hs
+++ b/src/Data/Barbie/Internal/Wear.hs
@@ -1,9 +1,12 @@
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE UndecidableInstances #-}
 module Data.Barbie.Internal.Wear
   ( Wear, Bare, Covered
   )
 
 where
+
+import GHC.TypeLits (ErrorMessage (..), TypeError)
 
 data Bare
 data Covered
@@ -31,3 +34,8 @@ data Covered
 type family Wear t f a where
   Wear Bare    f a = a
   Wear Covered f a = f a
+  Wear t       _ _ = TypeError (     'Text "`Wear` should only be used with "
+                               ':<>: 'Text "`Bare` or `Covered`."
+                               ':$$: 'Text "`" ':<>: 'ShowType t ':<>: 'Text "`"
+                               ':<>: 'Text " is not allowed in this context."
+                               )


### PR DESCRIPTION
Currently `Bare` and `Covered` are plain types with kind `*`, so nothing prevents someone setting `t` to a type other than these two when using `Wear`. This will lead to `Wear` being stuck. Another approach is using `DataKinds`:
```
data Clothes = Bare | Covered

type family Wear (t :: Clothes) f a where
  Wear Bare f a = a
  Wear Covered f a = f a
```
This 1) introduces a breaking change and 2) forces users to use `DataKinds`.

This PR adds a catch-all case to `Wear` which raises a type error that looks like this:
```
> data MyTag
> undefined :: Wear MyTag Maybe String

<interactive>:8:1: error:
    • `Wear` should only be used with `Bare` or `Covered`.
      `MyTag` is not allowed in this context.
    • When checking the inferred type
        it :: (TypeError ...)
```
which is backwards compatible with current code that uses `Wear`