### PR TITLE
Make the code work on GHC 8.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ matrix:
     - env: STACK_YAML=stack-ghc-802.yaml
     - env: STACK_YAML=stack-ghc-822.yaml
     - env: STACK_YAML=stack-ghc-844.yaml
-    - env: STACK_YAML=stack-ghc-864.yaml
+    - env: STACK_YAML=stack-ghc-865.yaml
+    - env: STACK_YAML=stack-ghc-881.yaml
 
 script:
   - travis_wait 240 stack --no-terminal --install-ghc --skip-ghc-check test

--- a/src/Data/Barbie/Internal/Constraints.hs
+++ b/src/Data/Barbie/Internal/Constraints.hs
@@ -179,7 +179,7 @@ gbaddDictsDefault
 class GAllBC (repbf :: * -> *) where
   type GAllB (c :: k -> Constraint) repbf :: Constraint
 
-class GAllBC repbx => GConstraintsB c (f :: k -> *) repbx repbf repbdf where
+class GAllBC repbx => GConstraintsB c f repbx repbf repbdf where
   gbaddDicts :: GAllB c repbx => repbf x -> repbdf x
 
 

--- a/src/Data/Barbie/Internal/Instances.hs
+++ b/src/Data/Barbie/Internal/Instances.hs
@@ -16,6 +16,8 @@ import Data.Barbie.Internal.ProductC
 import Data.Kind (Type)
 import Data.Semigroup (Semigroup, (<>))
 
+import Prelude hiding (Semigroup, (<>))  -- ghc < 8.2
+
 -- | A wrapper for Barbie-types, providing useful instances.
 newtype Barbie (b :: (k -> Type) -> Type) f
   = Barbie { getBarbie :: b f }

--- a/src/Data/Barbie/Trivial.hs
+++ b/src/Data/Barbie/Trivial.hs
@@ -18,6 +18,7 @@ import Data.Semigroup (Semigroup(..))
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 
+import Prelude hiding (Semigroup(..))
 
 ---------------------------------------------------
 -- Trivial Barbies

--- a/stack-ghc-864.yaml
+++ b/stack-ghc-864.yaml
@@ -1,4 +1,0 @@
-resolver: lts-13.14
-
-packages:
-- .

--- a/stack-ghc-865.yaml
+++ b/stack-ghc-865.yaml
@@ -1,0 +1,4 @@
+resolver: lts-14.4
+
+packages:
+- .

--- a/stack-ghc-881.yaml
+++ b/stack-ghc-881.yaml
@@ -1,0 +1,9 @@
+resolver: lts-14.4
+compiler: ghc-8.8.1 # no lts for ghc 8.8.1 yet
+
+packages:
+- .
+
+extra-deps:
+- Cabal-3.0.0.0
+- optparse-applicative-0.15.0.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-stack-ghc-865.yaml
+stack-ghc-881.yaml

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-stack-ghc-864.yaml
+stack-ghc-865.yaml


### PR DESCRIPTION
In GHC 8.8, `TypeApplications` can be used to apply kinds that were before unavailable. Unfortunately, this breaks the code in places where we were already using applications but the kind wasn't there. In order to make the code work with previous versions of ghc as well, we introduce explicit type proxies.

Fixes #16 