### PR TITLE
Add generic instances for barbies within nested Functors

### DIFF
--- a/src/Barbies/Internal/ApplicativeB.hs
+++ b/src/Barbies/Internal/ApplicativeB.hs
@@ -175,6 +175,26 @@ instance
     = Rec (K1 (bprod <$> hbf <*> hbg))
   {-# INLINE gprod #-}
 
+-- This is the same as the previous instance, but for nested Applicatives.
+instance
+  ( Applicative h
+  , Applicative m
+  , ApplicativeB b
+  ) => GApplicative 0 f g (Rec (m' (h' (b' (P 0 f)))) (m (h (b f))))
+                          (Rec (m' (h' (b' (P 0 g)))) (m (h (b g))))
+                          (Rec (m' (h' (b' (P 0 (f `Product` g))))) (m (h (b (f `Product` g)))))
+  where
+  gpure _ _ _ _ x
+    = Rec (K1 (pure . pure $ bpure x))
+  {-# INLINE gpure #-}
+
+  gprod _ _ _ (Rec (K1 hbf)) (Rec (K1 hbg))
+    = Rec (K1 (go <$> hbf <*> hbg))
+    where
+      go a b = bprod <$> a <*> b
+  {-# INLINE gprod #-}
+
+
 -- --------------------------------
 -- Instances for base types
 -- --------------------------------

--- a/src/Barbies/Internal/BareB.hs
+++ b/src/Barbies/Internal/BareB.hs
@@ -102,3 +102,18 @@ instance
 
   gcover _ = Rec . K1 . fmap bcover . unK1 . unRec
   {-# INLINE gcover #-}
+
+-- This instance is the same as the previous, but for nested Functors
+instance
+  ( Functor h
+  , Functor m
+  , BareB b
+  ) =>
+       GBare 0 (Rec (m' (h' (b' (P 1 Covered) (P 0 Identity)))) (m (h (b Covered Identity))))
+               (Rec (m' (h' (b' (P 1 Bare)    (P 0 Identity)))) (m (h (b Bare    Identity))))
+  where
+  gstrip _ = Rec . K1 . fmap (fmap bstrip) . unK1 . unRec
+  {-# INLINE gstrip #-}
+
+  gcover _ = Rec . K1 . fmap (fmap bcover) . unK1 . unRec
+  {-# INLINE gcover #-}

--- a/src/Barbies/Internal/FunctorB.hs
+++ b/src/Barbies/Internal/FunctorB.hs
@@ -89,6 +89,18 @@ instance
   gmap _ h (Rec (K1 hbf)) = Rec (K1 (fmap (bmap h) hbf))
   {-# INLINE gmap #-}
 
+-- This is the same as the previous instance, but for nested (normal-flavoured)
+-- functors.
+instance
+  ( Functor h
+  , Functor m
+  , FunctorB b
+  ) => GFunctor 0 f g (Rec (m' (h' (b' (P 0 f)))) (m (h (b f))))
+                      (Rec (m' (h' (b' (P 0 g)))) (m (h (b g))))
+  where
+  gmap _ h (Rec (K1 hbf)) = Rec (K1 (fmap (fmap (bmap h)) hbf))
+  {-# INLINE gmap #-}
+
 
 -- --------------------------------
 -- Instances for base types

--- a/src/Barbies/Internal/TraversableB.hs
+++ b/src/Barbies/Internal/TraversableB.hs
@@ -129,6 +129,19 @@ instance
     = fmap (Rec . K1) . traverse (btraverse h) . unK1 . unRec
   {-# INLINE gtraverse #-}
 
+-- This instance is the same as the previous instance but for nested
+-- Traversables.
+instance
+   ( Traversable h
+   , Traversable m
+   , TraversableB b
+   ) => GTraversable 0 f g (Rec (m' (h' (b' (P 0 f)))) (m (h (b f))))
+                           (Rec (m' (h' (b' (P 0 g)))) (m (h (b g))))
+  where
+  gtraverse _ h
+    = fmap (Rec . K1) . traverse (traverse (btraverse h)) . unK1 . unRec
+  {-# INLINE gtraverse #-}
+
 
 -- ---------------------------------------------------------------------
 -- We roll our own State/efficient-Writer monad, not to add dependencies

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -45,9 +45,11 @@ main
 
             , Functor.laws @CompositeRecord
             , Functor.laws @NestedF
+            , Functor.laws @Nested2F
 
             , Functor.laws @(CompositeRecordW Covered)
             , Functor.laws @(NestedFW Covered)
+            , Functor.laws @(Nested2FW Covered)
             ]
 
         , testGroup "Traversable Laws"
@@ -74,9 +76,11 @@ main
 
             , Traversable.laws @CompositeRecord
             , Traversable.laws @NestedF
+            , Traversable.laws @Nested2F
 
             , Traversable.laws @(CompositeRecordW Covered)
             , Traversable.laws @(NestedFW Covered)
+            , Traversable.laws @(Nested2FW Covered)
             ]
 
         , testGroup "Applicative laws"
@@ -85,6 +89,7 @@ main
             , Applicative.laws @Record3
             , Applicative.laws @CompositeRecord
             , Applicative.laws @NestedF
+            , Applicative.laws @Nested2F
 
             , Applicative.laws @Record1S
             , Applicative.laws @Record3S
@@ -93,6 +98,7 @@ main
             , Applicative.laws @(Record3W Covered)
             , Applicative.laws @(CompositeRecordW Covered)
             , Applicative.laws @(NestedFW Covered)
+            , Applicative.laws @(Nested2FW Covered)
 
             , Applicative.laws @(Record1WS Covered)
             , Applicative.laws @(Record3WS Covered)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -47,6 +47,7 @@ main
             , Functor.laws @NestedF
 
             , Functor.laws @(CompositeRecordW Covered)
+            , Functor.laws @(NestedFW Covered)
             ]
 
         , testGroup "Traversable Laws"

--- a/test/TestBarbies.hs
+++ b/test/TestBarbies.hs
@@ -20,6 +20,7 @@ module TestBarbies
   , InfRec(..)
 
   , NestedF(..)
+  , Nested2F(..)
 
   , HKB(..)
   )
@@ -251,6 +252,22 @@ instance (Arbitrary (f Int), AllBF Arbitrary f Record3) => Arbitrary (NestedF f)
         NestedF <$> arbitrary <*> scale (`div` 2) arbitrary <*> arbitrary
 
 
+data Nested2F f
+  = Nested2F
+    { np2f_1 :: f Int
+    , np2f_2 :: [Maybe (Nested2F f)]
+    }
+  deriving (Generic, Typeable)
+
+instance FunctorB Nested2F
+instance TraversableB Nested2F
+instance ApplicativeB Nested2F
+
+deriving instance Show (f Int) => Show (Nested2F f)
+deriving instance Eq (f Int) => Eq (Nested2F f)
+
+instance Arbitrary (f Int) => Arbitrary (Nested2F f) where
+  arbitrary = scale (`div` 2) $ Nested2F <$> arbitrary <*> scale (`div` 2) arbitrary
 
 -----------------------------------------------------
 -- Parametric barbies

--- a/test/TestBarbiesW.hs
+++ b/test/TestBarbiesW.hs
@@ -17,6 +17,7 @@ module TestBarbiesW
   , InfRecW(..)
 
   , NestedFW(..)
+  , Nested2FW(..)
   )
 
 where
@@ -267,6 +268,29 @@ instance (Arbitrary (f Int), Arbitrary (f Bool), Arbitrary (f Char)) => Arbitrar
   arbitrary
     = scale (`div` 2) $
         NestedFW <$> arbitrary <*> scale (`div` 2) arbitrary <*> arbitrary
+
+
+data Nested2FW t f
+  = Nested2FW
+    { np2fw_1 :: Wear t f Int
+    , np2fw_2 :: [Maybe (Nested2FW t f)]
+    }
+  deriving (Generic, Typeable)
+
+instance FunctorB (Nested2FW Bare)
+instance FunctorB (Nested2FW Covered)
+instance TraversableB (Nested2FW Bare)
+instance TraversableB (Nested2FW Covered)
+instance ApplicativeB (Nested2FW Covered)
+instance BareB Nested2FW
+
+deriving instance Show (Nested2FW Bare f)
+deriving instance Eq (Nested2FW Bare f)
+deriving instance Show (f Int) => Show (Nested2FW Covered f)
+deriving instance Eq (f Int) => Eq (Nested2FW Covered f)
+
+instance Arbitrary (f Int) => Arbitrary (Nested2FW Covered f) where
+  arbitrary = scale (`div` 2) $ Nested2FW <$> arbitrary <*> scale (`div` 2) arbitrary
 
 
 -----------------------------------------------------


### PR DESCRIPTION
This commit allows generic deriving in code like the following, where multiple (normal-flavoured) `Functor`s are nested around our `Barbie`:

```
data Two a = Two a a
  deriving ( Eq, Ord, Show, Generic, Functor, Foldable, Traversable )

data Foo f
  = Foo (f Int)
  | Bar [Two (Foo f)]
  deriving ( Generic, FunctorB, TraversableB )
```
