### PR TITLE
Add the `Thin` marker type

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for barbies
 
+## ?
+  - Add `Barbies.Bare.Thin` marker type to support having _field-specific_
+    newtype wrappers that get applied only to the covered barbie.
+
 ## 2.0.0.0
   - Builds with ghc 8.8, but drops support for ghc 8.0 and 8.2
   - Fix failure to derive `TraversableB` and `ConstraintsB` when using a type

--- a/src/Barbies/Bare.hs
+++ b/src/Barbies/Bare.hs
@@ -44,10 +44,13 @@ module Barbies.Bare
   , bstripFrom
   , bcoverWith
 
+  , Thin
+
   ) where
 
 import Barbies.Internal.BareB
   ( Wear, Bare, Covered
   , BareB(..)
   , bstripFrom, bcoverWith
+  , Thin
   )

--- a/src/Barbies/Generics/Bare.hs
+++ b/src/Barbies/Generics/Bare.hs
@@ -8,7 +8,7 @@ where
 
 import Data.Functor.Identity (Identity(..))
 
-import Data.Coerce (coerce)
+import Data.Coerce (Coercible, coerce)
 import Data.Generics.GenericN
 import Data.Proxy (Proxy(..))
 import GHC.TypeLits (Nat)
@@ -67,7 +67,7 @@ instance (GBare n l l', GBare n r r') => GBare n (l :+: r) (l' :+: r') where
 
 type P = Param
 
-instance GBare n (Rec (P n Identity a) (Identity a)) (Rec a a) where
+instance Coercible a b => GBare n (Rec (P n Identity a) (Identity a)) (Rec b b) where
   gstrip _ = coerce
   {-# INLINE gstrip #-}
 

--- a/src/Barbies/Internal/BareB.hs
+++ b/src/Barbies/Internal/BareB.hs
@@ -5,6 +5,7 @@ module Barbies.Internal.BareB
   ( Wear, Bare, Covered
   , BareB(..)
   , bstripFrom, bcoverWith
+  , Thin
 
   , gbstripDefault
   , gbcoverDefault
@@ -16,7 +17,7 @@ where
 
 import Barbies.Generics.Bare(GBare(..))
 import Barbies.Internal.FunctorB (FunctorB(..))
-import Barbies.Internal.Wear(Bare, Covered, Wear)
+import Barbies.Internal.Wear(Bare, Covered, Wear, Thin)
 import Data.Functor.Identity (Identity(..))
 
 import Data.Generics.GenericN

--- a/src/Barbies/Internal/Wear.hs
+++ b/src/Barbies/Internal/Wear.hs
@@ -1,16 +1,58 @@
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE UndecidableInstances #-}
 module Barbies.Internal.Wear
-  ( Wear, Bare, Covered
+  ( Wear, Bare, Covered, Thin
   )
 
 where
 
+import Data.Kind (Type)
 import GHC.TypeLits (ErrorMessage (..), TypeError)
 import Data.Generics.GenericN (Param)
 
 data Bare
 data Covered
+
+-- | 'Thin' is a marker type whose purpose is to influence the behaviour
+-- of the `Wear` type family. It can not be instantiated.
+--
+-- @Thin f@ adds an @f@ wrapper to a field iff the barbie is covered.
+-- This allows /field-specific/ wrappers that get removed when stripping
+-- (and added when covering) automatically by the Generic-derived instances.
+-- @f@ /must/ be a plain newtype wrapper, i.e. it requires that
+-- @Coercible a (f a)@ holds.
+--
+-- As an example and showcase, consider this barbie type:
+--
+-- @
+-- data T t f =
+--   T { f1 :: 'Wear' t f Int
+--     , f2 :: 'Wear' t f (Sum Int)
+--     , f3 :: 'Wear' t f (Maybe Int)
+--     , f4 :: 'Wear' t f (Thin Sum Int)
+--     -- , f5 :: 'Wear' t f (Thin Maybe Int)
+--     -- not allowed, because 'Maybe' is no newtype
+--     }
+-- @
+--
+-- with @x :: T Covered IO@ we would have
+--
+-- @
+-- f1 x :: IO Int
+-- f2 x :: IO (Sum Int)
+-- f3 x :: IO (Maybe Int)
+-- f4 x :: IO (Sum Int)
+-- @
+--
+-- and with @y :: T Bare Identity@ we would have
+--
+-- @
+-- f1 y :: Int
+-- f2 y :: Sum Int
+-- f3 y :: Maybe Int
+-- f4 y :: Int           -- Thin removes the Sum wrapper when bare
+-- @
+data Thin (f :: Type -> Type) (a :: Type)
 
 -- | The 'Wear' type-function allows one to define a Barbie-type as
 --
@@ -33,8 +75,10 @@ data Covered
 -- B { f1 :: 5, f2 = 'True' } :: B 'Bare' f
 -- @
 type family Wear t f a where
-  Wear Bare    f a = a
-  Wear Covered f a = f a
+  Wear Bare    f (Thin g a) = a
+  Wear Bare    f a          = a
+  Wear Covered f (Thin g a) = f (g a)
+  Wear Covered f a          = f a
   Wear (Param _ t) f a = Wear t f a
   Wear t       _ _ = TypeError (     'Text "`Wear` should only be used with "
                                ':<>: 'Text "`Bare` or `Covered`."


### PR DESCRIPTION
As discussed in #28.

I haven't tested this fully yet but the following example seems to work fine so far. It depends on an unreleased (and entirely unpublished) feature of the `butcher` library and does not make use of the `Semigroup` fields, but it is a good first test:

~~~~.hs
{-# LANGUAGE ApplicativeDo #-}
import qualified UI.Butcher.Applicative as Bu
import qualified Barbies                as Ba
import qualified Barbies.Bare           as Ba
import           Data.Semigroup (Any, Max, Last)

data Color = Red | Green | Blue deriving (Show, Read)
data MyFlags c f = MyFlags
  { dryrun     :: Ba.Wear c f (Thin Any Bool)
  , verbosity  :: Ba.Wear c f (Thin Max Int)
  , myUIColor  :: Ba.Wear c f (Thin Last Color)
  , exclude    :: Ba.Wear c f [Text]
  }
  deriving Generic

instance Ba.FunctorB     (MyFlags Ba.Covered)
instance Ba.TraversableB (MyFlags Ba.Covered)
instance Ba.BareB        MyFlags

main :: IO ()
main = Bu.mainFromCmdParser $ do -- parser applicative
  let flagParser = MyFlags
        { dryrun    = Any <$> addSimpleBoolFlag "d" ["dryrun"] mempty
        , verbosity = Max <$> addFlagReadParam "v" ["verbosity"] (flagDefault 0)
        , myUIColor =         addFlagReadParam "c" ["color"] mempty
        }
  flags <- Bu.traverseParser flagParser
  pure $ do -- IO monad
    when (dryrun flags) $ do
      putStrLn "I would do important stuff"
      exit 0
    when (verbosity flags>=2) $ do
      putStrLn "program started"
    putStrLn ("imagine this text was colored " ++ show (myUIColor flags))
~~~~

The flagParser is a barbie covered in a parser applicative (butcher's CmdParser). Fancy stuff :)