### PR TITLE
Add flipped-argument versions of traverse-style functions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,16 @@
 # Changelog for barbies
 
+## Unreleased (minor)
+  - Add flipped-argument versions of `traverse` functions. By analogy
+    to `Data.Traversable.for` in `base` these are similarly-named:
+    - `Data.Barbie.bfor`
+    - `Data.Barbie.bfor_`
+    - `Data.Barbie.bforC`
+    - `Data.Functor.Transformer.tfor`
+    - `Data.Functor.Transformer.tforC`
+    - `Data.Functor.Transformer.tfor_`
+    - `Barbies.Bi.btfor1`
+
 ## 2.0.4.0
   - Add FunctorT and DistributiveT instances for AccumT
 

--- a/src/Barbies/Bi.hs
+++ b/src/Barbies/Bi.hs
@@ -20,6 +20,7 @@ module Barbies.Bi
     --   and a 'TraversableB'.
   , bttraverse
   , bttraverse1
+  , btfor1
   , bttraverse_
   , btfoldMap
 
@@ -108,6 +109,17 @@ bttraverse1
 bttraverse1 h
   = bttraverse h h
 {-# INLINE bttraverse1 #-}
+
+-- | 'bttraverse1' with the arguments flipped.
+btfor1
+  :: ( TraversableB (b f)
+     , TraversableT b
+     , Monad t
+     )
+  => b f f
+  -> (forall a . f a -> t (g a))
+  -> t (b g g)
+btfor1 b f = bttraverse1 f b
 
 -- | Map each element to an action, evaluate these actions from left to right
 --   and ignore the results.

--- a/src/Barbies/Internal/ConstraintsB.hs
+++ b/src/Barbies/Internal/ConstraintsB.hs
@@ -7,6 +7,7 @@ module Barbies.Internal.ConstraintsB
   ( ConstraintsB(..)
   , bmapC
   , btraverseC
+  , bforC
   , AllBF
   , bdicts
   , bpureC
@@ -137,6 +138,19 @@ btraverseC
   -> e (b g)
 btraverseC f b
   = btraverse (\(Pair (Dict :: Dict c a) x) -> f x) (baddDicts b)
+
+-- | 'btraverseC' with the arguments flipped. Useful when the traversing function is a large lambda:
+--
+-- @
+-- bforC someBarbie $ \fa -> ...
+-- @
+bforC
+  :: forall c b f g e
+  .  (TraversableB b, ConstraintsB b, AllB c b, Applicative e)
+  => b f
+  -> (forall a. c a => f a -> e (g a))
+  -> e (b g)
+bforC b f = btraverseC @c f b
 
 bfoldMapC
   :: forall c b m f

--- a/src/Barbies/Internal/ConstraintsT.hs
+++ b/src/Barbies/Internal/ConstraintsT.hs
@@ -7,6 +7,7 @@ module Barbies.Internal.ConstraintsT
   ( ConstraintsT(..)
   , tmapC
   , ttraverseC
+  , tforC
   , AllTF
   , tdicts
   , tpureC
@@ -121,6 +122,16 @@ ttraverseC
   -> e (t g x)
 ttraverseC f t
   = ttraverse (\(Pair (Dict :: Dict c a) x) -> f x) (taddDicts t)
+
+-- | Like 'ttraverseC' but with the arguments flipped.
+tforC
+  :: forall c t f g e x
+  .  (TraversableT t, ConstraintsT t, AllT c t, Applicative e)
+  => t f x
+  -> (forall a. c a => f a -> e (g a))
+  -> e (t g x)
+tforC t f
+  = ttraverseC @c f t
 
 -- | Like 'Data.Functor.Transformer.tfoldMap' but with a constraint on the function.
 tfoldMapC

--- a/src/Barbies/Internal/TraversableB.hs
+++ b/src/Barbies/Internal/TraversableB.hs
@@ -3,7 +3,9 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Barbies.Internal.TraversableB
   ( TraversableB(..)
+  , bfor
   , btraverse_
+  , bfor_
   , bsequence
   , bsequence'
   , bfoldMap
@@ -50,6 +52,17 @@ class FunctorB b => TraversableB (b :: (k -> Type) -> Type) where
     -> e (b g)
   btraverse = gbtraverseDefault
 
+-- | 'btraverse' with the arguments flipped. Useful when the traversing function is a large lambda:
+--
+-- @
+-- bfor someBarbie $ \fa -> ...
+-- @
+bfor
+  :: (TraversableB b, Applicative e)
+  => b f
+  -> (forall a . f a -> e (g a))
+  -> e (b g)
+bfor b f = btraverse f b
 
 
 -- | Map each element to an action, evaluate these actions from left to right,
@@ -61,6 +74,14 @@ btraverse_
   -> e ()
 btraverse_ f
   = void . btraverse (fmap (const $ Const ()) . f)
+
+-- | 'btraverse_' with the arguments flipped.
+bfor_
+  :: (TraversableB b, Applicative e)
+  => b f
+  -> (forall a. f a -> e c)
+  -> e ()
+bfor_ b f = btraverse_ f b
 
 
 -- | Evaluate each action in the structure from left to right,

--- a/src/Barbies/Internal/TraversableT.hs
+++ b/src/Barbies/Internal/TraversableT.hs
@@ -4,7 +4,9 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Barbies.Internal.TraversableT
   ( TraversableT(..)
+  , tfor
   , ttraverse_
+  , tfor_
   , tsequence
   , tsequence'
   , tfoldMap
@@ -60,6 +62,17 @@ class FunctorT t => TraversableT (t :: (k -> Type) -> k' -> Type) where
     => (forall a . f a -> e (g a)) -> t f x -> e (t g x)
   ttraverse = ttraverseDefault
 
+-- | 'ttraverse' with the arguments flipped. Useful when the traversing function is a large lambda:
+--
+-- @
+-- tfor someTransformer $ \fa -> ...
+-- @
+tfor
+  :: (TraversableT t, Applicative e)
+  => t f x
+  -> (forall a . f a -> e (g a))
+  -> e (t g x)
+tfor t f = ttraverse f t
 
 
 -- | Map each element to an action, evaluate these actions from left to right,
@@ -70,6 +83,14 @@ ttraverse_
   -> t f x -> e ()
 ttraverse_ f
   = void . ttraverse (fmap (const $ Const ()) . f)
+
+-- | 'ttraverse_' with the arguments flipped.
+tfor_
+  :: (TraversableT t, Applicative e)
+  => t f x
+  -> (forall a . f a -> e c)
+  -> e ()
+tfor_ t f = ttraverse_ f t
 
 
 -- | Evaluate each action in the structure from left to right,

--- a/src/Data/Barbie.hs
+++ b/src/Data/Barbie.hs
@@ -8,7 +8,9 @@ module Data.Barbie
     -- * Traversable
   , TraversableB(btraverse)
     -- ** Utility functions
+  , bfor
   , btraverse_
+  , bfor_
   , bfoldMap
   , bsequence, bsequence'
 
@@ -29,6 +31,7 @@ module Data.Barbie
     -- ** Utility functions
   , bmapC
   , btraverseC
+  , bforC
 
     -- * Products and constaints
   , ProductBC(bdicts)
@@ -55,7 +58,7 @@ module Data.Barbie
 
 where
 
-import Barbies.Internal.ConstraintsB (AllBF, ConstraintsB (..), bmapC, btraverseC, bmempty)
+import Barbies.Internal.ConstraintsB (AllBF, ConstraintsB (..), bforC, bmapC, btraverseC, bmempty)
 
 import Barbies.Internal.FunctorB(FunctorB(..))
 import Barbies.Internal.Wrappers(Barbie(..))
@@ -66,8 +69,9 @@ import Data.Barbie.Internal.ProductC(ProductBC(..), CanDeriveProductBC,  GProduc
 
 import Barbies.Internal.TraversableB
   ( TraversableB(..)
+  , bfor
   , bsequence, bsequence'
-  , bfoldMap, btraverse_
+  , bfoldMap, btraverse_, bfor_
   )
 import qualified Barbies.Internal.Trivial as Trivial
 

--- a/src/Data/Functor/Transformer.hs
+++ b/src/Data/Functor/Transformer.hs
@@ -12,7 +12,9 @@ module Data.Functor.Transformer
     -- * Traversable
   , Trav.TraversableT(ttraverse)
     -- ** Utility functions
+  , Trav.tfor
   , Trav.ttraverse_
+  , Trav.tfor_
   , Trav.tfoldMap
   , Trav.tsequence
   , Trav.tsequence'
@@ -43,6 +45,7 @@ module Data.Functor.Transformer
     -- ** Utility functions
   , Cons.tmapC
   , Cons.ttraverseC
+  , Cons.tforC
 
     -- * Support for generic derivations
   , GenericsN.Rec(..)


### PR DESCRIPTION
`Data.Traversable` has `for = flip traverse`, which is very useful when then traversing function is a large lambda and can hang off to the right of an expression. This PR adds `for` variants for every `traverse`-style function where it appears to make sense. They're more important in this library than in `base`, actually, because it's harder to get things like `fliip btraverse` to typecheck on HKD than the equivalent on a regular `Traversable`.